### PR TITLE
fixes setSource infinite loop

### DIFF
--- a/ios/RNPhotoView.m
+++ b/ios/RNPhotoView.m
@@ -290,14 +290,14 @@
 - (void)setSource:(NSDictionary *)source {
     __weak RNPhotoView *weakSelf = self;
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        if ([weakSelf.source isEqualToDictionary:source]) {
+        if ([_source isEqualToDictionary:source]) {
             return;
         }
         NSString *uri = source[@"uri"];
         if (!uri) {
             return;
         }
-        weakSelf.source = source;
+        _source = source;
         NSURL *imageURL = [NSURL URLWithString:uri];
 
         if (![[uri substringToIndex:4] isEqualToString:@"http"]) {


### PR DESCRIPTION
Seems like there is an infinite loop problem:`onLoadStart` and `onLoad` callbacks are triggered multiples times while `PhotoView` component is mounted.

I fixed the problem by reverting the `_source` change.  Maybe `weakSelf.source = source` invokes again `setSource`?

The react code where I found this issue looks like this:

```jsx
function MyComponent({ source, width, height }) {
  const start = useRef(0);
  return (
    <PhotoView
      source={source}
      style={{ width, height }}
      onLoadStart={() => {
        console.log('loadStart');
        start.current = Date.now();
      }}
      onProgress={({ nativeEvent: { loaded, total } }) => console.log(loaded, total)}
      onLoad={() => {
        console.log('onLoad', Date.now() - start.current, source);
      }}
    />
  );
}
```

Disclaimer: I'm a total noob in this language.